### PR TITLE
filter out invalid rows in _renderChangedRows

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3158,7 +3158,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {Boolean} `true` if selection was successful, `false` otherwise.
    */
   this.selectCellByProp = function(row, prop, endRow, endProp, scrollToCell = true, changeListener = true) {
-    warn(toSingleLine`Deprecation warning: This method is going to be removed in the next release. 
+    warn(toSingleLine`Deprecation warning: This method is going to be removed in the next release.
       If you want to select a cell using props, please use the \`selectCell\` method.`);
 
     return this.selectCells([[row, prop, endRow, endProp]], scrollToCell, changeListener);
@@ -3529,8 +3529,16 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @param {Array} Array of visualRowIndexs that map to the changedRows
    */
   this._renderChangedRows = function(changedRows) {
+    /*
+     * Filtered rows get incorrecly translated indexes leading to null visual indexes
+     * which we should filter out before attempting to re-render.
+     * Underlying issue is possibly in the RecordTranslator logic.
+     * (https://github.com/handsontable/handsontable/issues/4442)
+     */
+    var validChangedRows = changedRows.filter((rowIndex) => rowIndex !== null);
+
     editorManager.destroyEditor(null);
-    instance.view.selectiveRender(changedRows);
+    instance.view.selectiveRender(validChangedRows);
 
     if (selection.isSelected()) {
       editorManager.prepareEditor();


### PR DESCRIPTION
@agreene-coursera 

### Context
* Filtered rows don't seem to have the correct visual translated indexes (looks related to https://github.com/handsontable/handsontable/issues/4442) 
* When rows with index of `null` get rendered, it causes a momentary render of an empty TD, which sometimes needs a table scroll to re-render correctly.
* This updates `_renderChangedRows()` to filter out such invalid rows

### How has this been tested?
* After filtering out `null` index rows, there's no more empty row rendering.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4442

